### PR TITLE
Fix duplicate score-upper-total id

### DIFF
--- a/reglas.html
+++ b/reglas.html
@@ -116,7 +116,7 @@
         </tr>
         <tr>
           <td>Total sección</td>
-          <td id="score-upper-total">-</td>
+          <td id="score-upper-total-sum">-</td>
         </tr>
         <tr>
           <td>Trío</td>


### PR DESCRIPTION
## Summary
- Rename duplicate `score-upper-total` ID to `score-upper-total-sum` in `reglas.html` to ensure uniqueness
- Validate uniqueness of all IDs in the document

## Testing
- `python - <<'PY'\nimport re,collections,sys\nhtml=open('reglas.html').read()\nids=re.findall(r'id="([^"]+)"', html)\nfrom collections import Counter\nc=Counter(ids)\nprint('Total ids:', len(ids))\nprint('Unique ids:', len(c))\nprint('Duplicates:', [id for id,count in c.items() if count>1])\nPY`

------
https://chatgpt.com/codex/tasks/task_e_688f386b9abc832cbc682b219a593f4e