### PR TITLE
Add distinct note sections to layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,11 @@
     <div id="scoreboard-container"></div>
     <div id="notes-container">
       <h2>📝 Anotaciones</h2>
-      <div id="notes-area"></div>
+      <div id="notes-area">
+        <div id="notes-upper" class="notes-section"></div>
+        <div id="notes-lower" class="notes-section"></div>
+        <div id="notes-totals" class="notes-section"></div>
+      </div>
     </div>
   </section>
   <section id="history" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -112,9 +112,9 @@ nav a:hover {
   margin-top: 20px;
 }
 #notes-area {
-  display: grid;
-  grid-template-rows: repeat(3, auto);
-  grid-row-gap: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   border: 2px solid #66a6ff;
   border-radius: 8px;
   padding: 8px;


### PR DESCRIPTION
## Summary
- Add dedicated containers for upper, lower, and total notes.
- Stack note sections vertically with flex layout for clarity.

## Testing
- `node /tmp/test-renderNotes.js`
- `npx -p jsdom node - <<'NODE' ...` *(failed: 403 Forbidden when fetching jsdom)*


------
https://chatgpt.com/codex/tasks/task_e_688f386a470c832cb77990a5f37fcd7a