### PR TITLE
Rename four-of-a-kind category to Cuarteo

### DIFF
--- a/reglas.html
+++ b/reglas.html
@@ -44,7 +44,7 @@
   <section>
     <h2>4. Sección inferior</h2>
     <div class="category"><strong>Trío:</strong> 3 dados iguales (suma de los 5 dados).</div>
-    <div class="category"><strong>Cuarteto:</strong> 4 dados iguales (suma de los 5 dados).</div>
+    <div class="category"><strong>Cuarteo:</strong> 4 dados iguales (suma de los 5 dados).</div>
     <div class="category"><strong>Full:</strong> 3+2 dados iguales (25 puntos).</div>
     <div class="category"><strong>Escalera pequeña:</strong> 4 dados en orden (30 puntos).</div>
     <div class="category"><strong>Escalera grande:</strong> 5 dados en orden (40 puntos).</div>
@@ -123,8 +123,8 @@
           <td id="score-trio">-</td>
         </tr>
         <tr>
-          <td>Cuarteto</td>
-          <td id="score-cuarteto">-</td>
+          <td>Cuarteo</td>
+          <td id="score-cuarteo">-</td>
         </tr>
         <tr>
           <td>Full</td>

--- a/script.js
+++ b/script.js
@@ -107,7 +107,7 @@ function renderScoreboard() {
   const rows = [
     'Unos', 'Doses', 'Treses', 'Cuatros', 'Cincos', 'Seises',
     'Total superior', 'Bonus (>=63 → +35)', 'Total sup. c/bonus',
-    'Trío', 'Póker', 'Full House', 'Escalera pequeña', 'Escalera grande', 'Kniffel', 'Chance',
+    'Trío', 'Cuarteo', 'Full House', 'Escalera pequeña', 'Escalera grande', 'Kniffel', 'Chance',
     'Total inferior', 'Puntuación total'
   ];
 


### PR DESCRIPTION
## Summary
- Rename four-of-a-kind scoring category from Póker to Cuarteo in rules and scoreboard

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f3a366314832c87b1b1ce0e40bdae