### PR TITLE
Rename four-of-a-kind category to Cuarteto

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,7 +107,7 @@ function renderScoreboard() {
   const rows = [
     'Unos', 'Doses', 'Treses', 'Cuatros', 'Cincos', 'Seises',
     'Total superior', 'Bonus (>=63 → +35)', 'Total sup. c/bonus',
-    'Trío', 'Póker', 'Full House', 'Escalera pequeña', 'Escalera grande', 'Kniffel', 'Chance',
+    'Trío', 'Cuarteto', 'Full House', 'Escalera pequeña', 'Escalera grande', 'Kniffel', 'Chance',
     'Total inferior', 'Puntuación total'
   ];
 


### PR DESCRIPTION
## Summary
- Rename four-of-a-kind category from Cuarteo to Cuarteto in rules and example table
- Update scoreboard generation script to label four-of-a-kind as Cuarteto

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f3a366314832c87b1b1ce0e40bdae