### PR TITLE
Preserve score inputs and show values

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,6 +133,7 @@ function renderScoreboard() {
     players.forEach((_, pi) => {
       const td = document.createElement('td'); td.id = `cell-${ri}-${pi}`;
       if ((ri <= 5) || (ri >= 9 && ri <= 15)) {
+        td.classList.add('with-input');
         const inp = document.createElement('input');
         inp.type = 'number'; inp.min = 0;
         inp.classList.add('score');
@@ -140,6 +141,9 @@ function renderScoreboard() {
         inp.dataset.row = ri;
         inp.addEventListener('input', onScoreChange);
         td.appendChild(inp);
+        const span = document.createElement('span');
+        span.classList.add('score-val');
+        td.appendChild(span);
       }
       tr.appendChild(td);
     });
@@ -162,6 +166,8 @@ function loadFromStorage() {
         const inp = cell.querySelector('input');
         if (inp) {
           inp.value = val;
+          const span = cell.querySelector('.score-val');
+          if (span) span.textContent = val;
         } else {
           cell.textContent = val;
         }
@@ -234,11 +240,13 @@ function calculateAll() {
     // Total general
     const total = sup + bonus + inf;
     document.getElementById(`cell-17-${p}`).textContent = total;
-    // Mostrar valores de inputs en sus celdas
+
+    // Actualizar la vista de los valores ingresados sin eliminar los inputs
     [...Array(6).keys(), ...Array(7).keys().map(i => i + 9)].forEach(r => {
       const cell = document.getElementById(`cell-${r}-${p}`);
       const inp = cell.querySelector('input');
-      if (inp) cell.textContent = inp.value || '';
+      const span = cell.querySelector('.score-val');
+      if (inp && span) span.textContent = inp.value || '';
     });
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -78,12 +78,21 @@ th {
   font-size: 0.9rem;
 }
 input.score {
-  width: 100%;
-  max-width: 60px;
+  width: 60px;
+  display: block;
+  margin: 0 auto;
   padding: 4px;
   border: 1px solid #ccc;
   border-radius: 4px;
   text-align: center;
+}
+td.with-input {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+td.with-input .score-val {
+  margin-top: 4px;
 }
 input.score:disabled {
   background: #f0f0f0;


### PR DESCRIPTION
## Summary
- keep score inputs in place and show their values with helper spans
- center input elements and align value displays
- update stored values to populate both inputs and their display spans

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f432abcfc832ca24aa06fab966f4e