### PR TITLE
Enforce maximum player limit

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,8 @@ buildNameFields();
 
 function buildNameFields() {
   inputsD.innerHTML = '';
-  const n = +pcSelect.value;
+  const n = Math.min(+pcSelect.value, maxPlayers);
+  pcSelect.value = n;
   for (let i = 1; i <= n; i++) {
     const inp = document.createElement('input');
     inp.type = 'text';


### PR DESCRIPTION
## Summary
- Integrate `maxPlayers` constant to cap the number of player name fields and keep the selector in sync.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f47adee8c832ca224b47743cd04e1