### PR TITLE
Remove player count selector and default to six player fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,7 @@
 
   <section id="registro">
     <h2>👥 Configuración de la partida</h2>
-    <label for="player-count">Número de jugadores:</label>
-    <select id="player-count">
-      <option value="2">2</option>
-      <option value="3">3</option>
-      <option value="4" selected>4</option>
-      <option value="5">5</option>
-      <option value="6">6</option>
-    </select>
+    <p>Introduce los nombres de los jugadores (hasta 6):</p>
     <div id="player-inputs"></div>
     <button id="start-game">¡Empezar partida!</button>
   </section>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,6 @@ let currentRow = 0;
 // Elementos del DOM
 const registro = document.getElementById('registro');
 const game = document.getElementById('game');
-const pcSelect = document.getElementById('player-count');
 const inputsD = document.getElementById('player-inputs');
 const start = document.getElementById('start-game');
 const nextBtn = document.getElementById('next-turn');
@@ -20,13 +19,11 @@ const historyList = document.getElementById('history-list');
 let history = JSON.parse(localStorage.getItem('kniffel_history') || '[]');
 
 // Inicializar campos de nombre
-pcSelect.addEventListener('change', buildNameFields);
 buildNameFields();
 
 function buildNameFields() {
   inputsD.innerHTML = '';
-  const n = +pcSelect.value;
-  for (let i = 1; i <= n; i++) {
+  for (let i = 1; i <= maxPlayers; i++) {
     const inp = document.createElement('input');
     inp.type = 'text';
     inp.placeholder = `Nombre jugador ${i}`;


### PR DESCRIPTION
## Summary
- Drop player count dropdown from the registration form.
- Always render six player name inputs by default and remove select references.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f47b8e9cc832c9cb7a4feb771b5e6