### PR TITLE
Include players in saved game history

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ newBtn.addEventListener('click', () => {
     return parseInt(document.getElementById(`cell-17-${p}`).textContent) || 0;
   });
   // Guardar en historial
-  history.push({ date: new Date().toLocaleString(), totals });
+  history.push({ date: new Date().toLocaleString(), players: [...players], totals });
   localStorage.setItem('kniffel_history', JSON.stringify(history));
   // Limpiar datos actuales
   Object.keys(localStorage)
@@ -93,7 +93,8 @@ function renderHistory() {
   historySec.classList.remove('hidden');
   historyList.innerHTML = history.map((gameItem, i) => {
     const title = `Partida ${i + 1} (${gameItem.date})`;
-    const cols = players.map(p => `<th>${p}</th>`).join('');
+    const names = gameItem.players || Array.from({ length: gameItem.totals.length }, (_, idx) => players[idx] || `Jugador ${idx + 1}`);
+    const cols = names.map(p => `<th>${p}</th>`).join('');
     const row = `<tr><td><strong>Total</strong></td>${gameItem.totals.map(t => `<td>${t}</td>`).join('')}</tr>`;
     return `
       <div class="history-game">


### PR DESCRIPTION
## Summary
- Store player names when saving a finished game
- Render history tables using saved player names with fallback for old entries

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f47d77aec832cbcea1cefd2c1744e