### PR TITLE
Add visible score spans in scoreboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,6 +149,9 @@ function renderScoreboard() {
         inp.dataset.row = ri;
         inp.addEventListener('change', onScoreChange);
         td.appendChild(inp);
+        const span = document.createElement('span');
+        span.classList.add('score-val');
+        td.appendChild(span);
         td.addEventListener('click', () => {
           currentRow = ri;
           currentTurn = pi;


### PR DESCRIPTION
## Summary
- show final score values in each scoreboard cell by adding span placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f47e2b50c832c856718b9b5d11430