### PR TITLE
Use flex wrapper for score inputs

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,16 +145,19 @@ function renderScoreboard() {
       const td = document.createElement('td'); td.id = `cell-${ri}-${pi}`;
       if ((ri <= 5) || (ri >= 9 && ri <= 15)) {
         td.classList.add('with-input');
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('score-wrapper');
         const inp = document.createElement('input');
         inp.type = 'number'; inp.min = 0;
         inp.classList.add('score');
         inp.dataset.player = pi;
         inp.dataset.row = ri;
         inp.addEventListener('change', onScoreChange);
-        td.appendChild(inp);
+        wrapper.appendChild(inp);
         const span = document.createElement('span');
         span.classList.add('score-val');
-        td.appendChild(span);
+        wrapper.appendChild(span);
+        td.appendChild(wrapper);
         td.addEventListener('click', () => {
           currentRow = ri;
           currentTurn = pi;

--- a/styles.css
+++ b/styles.css
@@ -87,11 +87,16 @@ input.score {
   text-align: center;
 }
 td.with-input {
+  /* contenedor de celdas con entradas */
+}
+
+.score-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
-td.with-input .score-val {
+
+.score-wrapper .score-val {
   margin-top: 4px;
 }
 input.score:disabled {


### PR DESCRIPTION
## Summary
- add `score-wrapper` div inside input cells and move flex styling to it
- adjust scoreboard generation to create wrapper and apply new styles

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688f50cd9a38832ca291ed662a4c8e8d