### PR TITLE
style: simplify font stack

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 /* styles.css (mobile-first) */
 
 body {
-  font-family: Arial, Verdana, "Franklin Gothic Medium", "Franklin Gothic", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   margin: 10px;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   color: #333;
@@ -10,7 +10,7 @@ body {
 h1,
 h2,
 h3 {
-  font-family: Arial, Verdana, "Franklin Gothic Medium", "Franklin Gothic", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- use system font stack for body and headings

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d1d068832ca42b6c54fedd0351