### PR TITLE
Remove unused with-input class from scoreboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,7 +143,6 @@ function renderScoreboard() {
     players.forEach((_, pi) => {
       const td = document.createElement('td'); td.id = `cell-${ri}-${pi}`;
       if ((ri <= 5) || (ri >= 9 && ri <= 15)) {
-        td.classList.add('with-input');
         const wrapper = document.createElement('div');
         wrapper.classList.add('score-wrapper');
         const inp = document.createElement('input');


### PR DESCRIPTION
## Summary
- Clean up scoreboard cell generation by dropping unused `with-input` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d7635c832ca1856a149382215c