### PR TITLE
Eliminar estilos de notas no utilizados

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -101,17 +101,6 @@ input.score:disabled {
   pointer-events: none;
 }
 
-/* Notas */
-#notes-area .notes-box {
-  width: 100%;
-  min-height: 80px;
-  margin-bottom: 10px;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  resize: vertical;
-}
-
 /* Enlaces */
 nav {
   text-align: center;
@@ -124,36 +113,6 @@ nav a {
 }
 nav a:hover {
   text-decoration: underline;
-}
-
-/* Zona de anotaciones con cuadricula separada */
-#notes-container {
-  margin-top: 20px;
-}
-#notes-area {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  border: 2px solid #66a6ff;
-  border-radius: 8px;
-  padding: 8px;
-}
-.notes-section {
-  border: 1px solid #89f7fe;
-  padding: 6px;
-  border-radius: 6px;
-}
-.notes-section h3 {
-  margin: 0 0 4px;
-  font-size: 0.9rem;
-  color: #66a6ff;
-}
-.notes-section textarea {
-  width: 100%;
-  min-height: 60px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  resize: vertical;
 }
 
 #history { max-width: 900px; margin: 20px auto; }


### PR DESCRIPTION
## Resumen
- Eliminar reglas CSS para secciones de notas y anotaciones no utilizadas

## Pruebas
- `npm test` *(falló: ENOENT no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d55184832ca769e13e53581642