### PR TITLE
feat: restrict score inputs to numeric

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,6 +148,8 @@ function renderScoreboard() {
         wrapper.classList.add('score-wrapper');
         const inp = document.createElement('input');
         inp.type = 'number'; inp.min = 0;
+        inp.inputMode = 'numeric';
+        inp.pattern = '\d*';
         inp.classList.add('score');
         inp.dataset.player = pi;
         inp.dataset.row = ri;

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,14 @@ input.score {
   border-radius: 4px;
   text-align: center;
 }
+input[type=number]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
 
 .score-wrapper {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure score inputs accept only numeric characters
- hide default browser spinners for numeric inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d491a0832c9b883f91f2687cf7