### PR TITLE
Replace gradient backgrounds with accessible solid colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 body {
   font-family: Arial, Verdana, "Franklin Gothic Medium", "Franklin Gothic", sans-serif;
   margin: 10px;
-  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  background-color: #e9ecef;
   color: #333;
 }
 
@@ -36,7 +36,7 @@ button {
   border-radius: 20px;
   font-weight: bold;
   cursor: pointer;
-  background: linear-gradient(45deg, #89f7fe, #66a6ff);
+  background-color: #005a9c;
   color: #fff;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   transition: transform 0.1s;
@@ -73,7 +73,7 @@ th, td {
   border-bottom: 1px solid #eee;
 }
 th {
-  background: linear-gradient(90deg, #ff9a9e, #fad0c4);
+  background-color: #005a9c;
   color: #fff;
   font-size: 0.9rem;
 }
@@ -118,7 +118,7 @@ nav {
   margin-top: 10px;
 }
 nav a {
-  color: #66a6ff;
+  color: #005a9c;
   text-decoration: none;
   font-weight: bold;
 }
@@ -134,19 +134,19 @@ nav a:hover {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border: 2px solid #66a6ff;
+  border: 2px solid #005a9c;
   border-radius: 8px;
   padding: 8px;
 }
 .notes-section {
-  border: 1px solid #89f7fe;
+  border: 1px solid #005a9c;
   padding: 6px;
   border-radius: 6px;
 }
 .notes-section h3 {
   margin: 0 0 4px;
   font-size: 0.9rem;
-  color: #66a6ff;
+  color: #005a9c;
 }
 .notes-section textarea {
   width: 100%;


### PR DESCRIPTION
## Summary
- use neutral gray background for body and dark blue for buttons and table headers
- darken link and notes heading colors and update note area borders for contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d2e7cc832cb8c1d1a242bd1f1c