### PR TITLE
Reset state when starting new game

### DIFF
--- a/script.js
+++ b/script.js
@@ -75,6 +75,9 @@ newBtn.addEventListener('click', () => {
   Object.keys(localStorage)
     .filter(k => k.startsWith('score_p'))
     .forEach(k => localStorage.removeItem(k));
+  players = [];
+  document.getElementById('scoreboard-container').innerHTML = '';
+  turnLbl.textContent = 'Turno de: —';
   // Actualizar historial en UI
   renderHistory();
   // Reiniciar UI


### PR DESCRIPTION
## Summary
- Reset players array, scoreboard, and turn label when starting a new game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55d11900832cb464ce164901bf6f