### PR TITLE
Improve turn flow, mobile presentation, and rules navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kniffel - Hoja de Puntuación</title>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/reglas.html
+++ b/reglas.html
@@ -10,6 +10,7 @@
 
 <body>
   <h1>Reglas de Kniffel</h1>
+  <button id="return-game">Volver al juego</button>
 
   <section>
     <h2>1. Preparación</h2>
@@ -158,6 +159,11 @@
     </table>
   </section>
 
+  <script>
+    document.getElementById('return-game').addEventListener('click', () => {
+      history.back();
+    });
+  </script>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -23,6 +23,21 @@ const scoreRows = [...Array(6).keys(), ...Array(7).keys()].map((_, i) =>
   i >= 6 ? i + 3 : i
 );
 
+function nextInputRow(row) {
+  const idx = scoreRows.indexOf(row);
+  return idx >= 0 && idx < scoreRows.length - 1 ? scoreRows[idx + 1] : row;
+}
+
+function advanceTurn() {
+  if (currentTurn < players.length - 1) {
+    currentTurn++;
+  } else {
+    currentTurn = 0;
+    currentRow = nextInputRow(currentRow);
+  }
+  updateTurnUI();
+}
+
 // Inicializar campos de nombre
 buildNameFields();
 
@@ -53,15 +68,7 @@ start.addEventListener('click', () => {
   updateTurnUI();
 });
 
-nextBtn.addEventListener('click', () => {
-  if (currentTurn < players.length - 1) {
-    currentTurn++;
-  } else {
-    currentTurn = 0;
-    currentRow++;
-  }
-  updateTurnUI();
-});
+nextBtn.addEventListener('click', advanceTurn);
 
 newBtn.addEventListener('click', () => {
   // Recoger totales actuales
@@ -229,13 +236,7 @@ function onScoreChange(e) {
   localStorage.setItem(`score_p${p}_r${r}`, e.target.value || 0);
   e.target.disabled = true;
   calculateAll();
-  if (currentTurn < players.length - 1) {
-    currentTurn++;
-  } else {
-    currentTurn = 0;
-    currentRow++;
-  }
-  updateTurnUI();
+  advanceTurn();
 }
 
 // Cálculos automáticos

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,11 @@ h3 {
   font-weight: 700;
 }
 
+/* Utilidades */
+.hidden {
+  display: none;
+}
+
 /* Contenedores */
 section {
   margin: 10px 0;


### PR DESCRIPTION
## Summary
- Add `.hidden` utility class so game and history sections stay hidden until needed.
- Introduce `advanceTurn` helper to skip automatic rows and streamline turn order.
- Align viewport settings for consistent mobile scaling.
- Add a "Volver al juego" button on the rules page that uses the browser history to avoid reloading the game state.

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688f5c65b0dc832cbe8c975c2571c89f